### PR TITLE
Fix attr resolution of resources

### DIFF
--- a/library/src/main/java/com/mikepenz/materialize/util/UIUtils.java
+++ b/library/src/main/java/com/mikepenz/materialize/util/UIUtils.java
@@ -39,7 +39,7 @@ public class UIUtils {
     public static int getThemeColor(Context ctx, @AttrRes int attr) {
         TypedValue tv = new TypedValue();
         if (ctx.getTheme().resolveAttribute(attr, tv, true)) {
-            return tv.data;
+            return tv.resourceId != 0 ? ContextCompat.getColor(ctx, tv.resourceId) : tv.data;
         }
         return 0;
     }


### PR DESCRIPTION
Previously, colors like `?android:attr/textColorPrimary` were not resolved correctly, since those are actually resources and not direct color ints.
This PR fixes that by checking if the resolved `TypedValue` has a `resourceId` set.